### PR TITLE
Remove model selection UI and set default model

### DIFF
--- a/client/src/components/Chat/Input/HeaderOptions.tsx
+++ b/client/src/components/Chat/Input/HeaderOptions.tsx
@@ -7,7 +7,6 @@ import { tConvoUpdateSchema, EModelEndpoint, isParamEndpoint } from 'librechat-d
 import type { TPreset, TInterfaceConfig } from 'librechat-data-provider';
 import { EndpointSettings, SaveAsPresetDialog, AlternativeSettings } from '~/components/Endpoints';
 import { PluginStoreDialog, TooltipAnchor } from '~/components';
-import { ModelSelect } from '~/components/Input/ModelSelect';
 import { useSetIndexOptions, useLocalize } from '~/hooks';
 import OptionsPopover from './OptionsPopover';
 import PopoverButtons from './PopoverButtons';
@@ -79,14 +78,6 @@ export default function HeaderOptions({
         <div className="my-auto lg:max-w-2xl xl:max-w-3xl">
           <span className="flex w-full flex-col items-center justify-center gap-0 md:order-none md:m-auto md:gap-2">
             <div className="z-[61] flex w-full items-center justify-center gap-2">
-              {interfaceConfig?.modelSelect === true && (
-                <ModelSelect
-                  conversation={conversation}
-                  setOption={setOption}
-                  showAbove={false}
-                  popover={true}
-                />
-              )}
               {!noSettings[endpoint] &&
                 interfaceConfig?.parameters === true &&
                 paramEndpoint === false && (

--- a/client/src/components/Input/ModelSelect/ModelSelect.tsx
+++ b/client/src/components/Input/ModelSelect/ModelSelect.tsx
@@ -1,7 +1,5 @@
-import { useGetModelsQuery } from 'librechat-data-provider/react-query';
 import type { TConversation } from 'librechat-data-provider';
 import type { TSetOption } from '~/common';
-import { multiChatOptions } from './options';
 
 type TGoogleProps = {
   showExamples: boolean;
@@ -22,29 +20,11 @@ export default function ModelSelect({
   popover = false,
   showAbove = true,
 }: TSelectProps) {
-  const modelsQuery = useGetModelsQuery();
-
-  if (!conversation?.endpoint) {
+  if (!conversation) {
     return null;
   }
 
-  const { endpoint: _endpoint, endpointType } = conversation;
-  const models = modelsQuery?.data?.[_endpoint] ?? [];
-  const endpoint = endpointType ?? _endpoint;
+  setOption('model')('get-4o-mini');
 
-  const OptionComponent = multiChatOptions[endpoint];
-
-  if (!OptionComponent) {
-    return null;
-  }
-
-  return (
-    <OptionComponent
-      conversation={conversation}
-      setOption={setOption}
-      models={models}
-      showAbove={showAbove}
-      popover={popover}
-    />
-  );
+  return null;
 }

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -9,7 +9,7 @@ import {
 import type { TPreset } from 'librechat-data-provider';
 import { useNewConvo, useAppStartup, useAssistantListMap } from '~/hooks';
 import { useGetConvoIdQuery, useHealthCheck } from '~/data-provider';
-import { getDefaultModelSpec, getModelSpecIconURL } from '~/utils';
+import { getModelSpecIconURL } from '~/utils';
 import { ToolCallsMapProvider } from '~/Providers';
 import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
@@ -47,20 +47,13 @@ export default function ChatRoute() {
     }
 
     if (conversationId === Constants.NEW_CONVO && endpointsQuery.data && modelsQuery.data) {
-      const spec = getDefaultModelSpec(startupConfig?.modelSpecs?.list);
-
       newConversation({
         modelsData: modelsQuery.data,
         template: conversation ? conversation : undefined,
-        ...(spec
-          ? {
-            preset: {
-              ...spec.preset,
-              iconURL: getModelSpecIconURL(spec),
-              spec: spec.name,
-            },
-          }
-          : {}),
+        preset: {
+          model: 'get-4o-mini',
+          iconURL: getModelSpecIconURL({ name: 'get-4o-mini' }),
+        },
       });
 
       hasSetConversation.current = true;
@@ -68,7 +61,10 @@ export default function ChatRoute() {
       newConversation({
         template: initialConvoQuery.data,
         /* this is necessary to load all existing settings */
-        preset: initialConvoQuery.data as TPreset,
+        preset: {
+          ...initialConvoQuery.data,
+          model: 'get-4o-mini',
+        } as TPreset,
         modelsData: modelsQuery.data,
         keepLatestMessage: true,
       });
@@ -78,19 +74,13 @@ export default function ChatRoute() {
       assistantListMap[EModelEndpoint.assistants] &&
       assistantListMap[EModelEndpoint.azureAssistants]
     ) {
-      const spec = getDefaultModelSpec(startupConfig?.modelSpecs?.list);
       newConversation({
         modelsData: modelsQuery.data,
         template: conversation ? conversation : undefined,
-        ...(spec
-          ? {
-            preset: {
-              ...spec.preset,
-              iconURL: getModelSpecIconURL(spec),
-              spec: spec.name,
-            },
-          }
-          : {}),
+        preset: {
+          model: 'get-4o-mini',
+          iconURL: getModelSpecIconURL({ name: 'get-4o-mini' }),
+        },
       });
       hasSetConversation.current = true;
     } else if (
@@ -99,7 +89,10 @@ export default function ChatRoute() {
     ) {
       newConversation({
         template: initialConvoQuery.data,
-        preset: initialConvoQuery.data as TPreset,
+        preset: {
+          ...initialConvoQuery.data,
+          model: 'get-4o-mini',
+        } as TPreset,
         modelsData: modelsQuery.data,
         keepLatestMessage: true,
       });


### PR DESCRIPTION
Remove the model selection UI from the chat screen and set 'get-4o-mini' as the default model.

* **ModelSelect Component:**
  - Remove the code that fetches available models using the `useGetModelsQuery` hook.
  - Set the default model to 'get-4o-mini'.
  - Remove the conditional rendering of different model selection components based on the endpoint type.
  - Update the component to always use 'get-4o-mini' as the model.

* **HeaderOptions Component:**
  - Remove the import and usage of the `ModelSelect` component.
  - Update the component to no longer render the model selection dropdown.

* **ChatRoute:**
  - Remove the code that sets the default model spec.
  - Update the `newConversation` function to always use 'get-4o-mini' as the model.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jainabhishek/LibreChat/pull/1?shareId=8a74692d-3814-4017-bbc4-fe4f0f2820a6).